### PR TITLE
feat: add AWS cli retry settings to init script

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -61,6 +61,10 @@ region=${region}
 subnet_id=${subnet_id}
 nics_num=${nics_num}
 
+# AWS retry settings (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html)
+export AWS_MAX_ATTEMPTS=150
+export AWS_RETRY_MODE=standard
+
 for (( i=1; i<nics_num; i++ ))
 do
   eni=$(aws ec2 create-network-interface --region "$region" --subnet-id "$subnet_id" --groups ${groups}) # groups should not be in quotes it needs to be a list


### PR DESCRIPTION
From AWS [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html#cli-usage-retries-modes-adaptive): 
> Any retry attempt will include an exponential backoff by a base factor of 2.

Settings used:
- in main.tf
```
cluster_size = 100
alb_additional_subnet_cidr_block = "10.0.64.0/24"
```
- in prerequisites.tf
```
public_subnets_cidr = ["10.0.0.0/20"]
private_subnets_cidr = ["10.0.16.0/20"]
```
Testing results:
```
aws lambda invoke --function-name ks-test-status-lambda --payload '{"type": "progress"}' --cli-binary-format raw-in-base64-out /dev/stdout | jq -r '.ready_for_clusterization | length'
100

# on ip-10-0-10-95.eu-west-1.compute.internal host
weka status
WekaIO v4.2.6 (CLI build 4.2.6)

       cluster: test (44e50129-f8b6-4069-bc0d-70363b7e46f4)
        status: OK (300 backend containers UP, 200 drives UP)
    protection: 16+2 (Fully protected)
     hot spare: 1 failure domains (3.63 TiB)
 drive storage: 360.01 TiB total
         cloud: connected
       license: Unlicensed

     io status: STARTED 33 seconds ago (300 io-nodes UP, 2700 Buckets UP)
    link layer: Ethernet
       clients: 0 connected
         reads: 0 B/s (0 IO/s)
        writes: 0 B/s (0 IO/s)
    operations: 0 ops/s
        alerts: 2 active alerts, use `weka alerts` to list them
```