### PR TITLE
feat: add tiering params for weka fs group create

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | Ssh key pair name to pass to the instances. | `string` | `null` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | IAM Role that will be used by AWS Lambdas, if not specified will be created automatically. If pre-created should match policy described in readme | `string` | `""` | no |
 | <a name="input_lambdas_dist"></a> [lambdas\_dist](#input\_lambdas\_dist) | Lambdas code dist | `string` | `"dev"` | no |
-| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"7c14f3a10c69ebb4f19e15b91d10d087"` | no |
+| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"375def37c0edee0a8ce87ae9b77d0430"` | no |
 | <a name="input_metadata_http_tokens"></a> [metadata\_http\_tokens](#input\_metadata\_http\_tokens) | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2) | `string` | `"required"` | no |
 | <a name="input_nat_public_subnet_cidr"></a> [nat\_public\_subnet\_cidr](#input\_nat\_public\_subnet\_cidr) | CIDR block for public subnet | `string` | `"10.0.2.0/24"` | no |
 | <a name="input_nfs_interface_group_name"></a> [nfs\_interface\_group\_name](#input\_nfs\_interface\_group\_name) | Interface group name. | `string` | `"weka-ig"` | no |
@@ -879,6 +879,8 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | <a name="input_tiering_enable_obs_integration"></a> [tiering\_enable\_obs\_integration](#input\_tiering\_enable\_obs\_integration) | Determines whether to enable object stores integration with the Weka cluster. Set true to enable the integration. | `bool` | `false` | no |
 | <a name="input_tiering_enable_ssd_percent"></a> [tiering\_enable\_ssd\_percent](#input\_tiering\_enable\_ssd\_percent) | When set\_obs\_integration is true, this variable sets the capacity percentage of the filesystem that resides on SSD. For example, for an SSD with a total capacity of 20GB, and the tiering\_ssd\_percent is set to 20, the total available capacity is 100GB. | `number` | `20` | no |
 | <a name="input_tiering_obs_name"></a> [tiering\_obs\_name](#input\_tiering\_obs\_name) | Name of an existing S3 bucket | `string` | `""` | no |
+| <a name="input_tiering_obs_start_demote"></a> [tiering\_obs\_start\_demote](#input\_tiering\_obs\_start\_demote) | Target tiering cue (in seconds) before starting upload data to OBS (turning it into read cache). Default is 10 seconds. | `number` | `10` | no |
+| <a name="input_tiering_obs_target_ssd_retention"></a> [tiering\_obs\_target\_ssd\_retention](#input\_tiering\_obs\_target\_ssd\_retention) | Target retention period (in seconds) before tiering to OBS (how long data will stay in SSD). Default is 86400 seconds (24 hours). | `number` | `86400` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block of the vpc | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_endpoint_ec2_create"></a> [vpc\_endpoint\_ec2\_create](#input\_vpc\_endpoint\_ec2\_create) | Create Ec2 VPC endpoint | `bool` | `false` | no |
 | <a name="input_vpc_endpoint_lambda_create"></a> [vpc\_endpoint\_lambda\_create](#input\_vpc\_endpoint\_lambda\_create) | Create Ec2 VPC endpoint | `bool` | `false` | no |

--- a/lambdas.tf
+++ b/lambdas.tf
@@ -117,6 +117,8 @@ resource "aws_lambda_function" "clusterize_lambda" {
       SET_OBS                      = var.tiering_enable_obs_integration
       OBS_NAME                     = var.tiering_obs_name
       OBS_TIERING_SSD_PERCENT      = var.tiering_enable_ssd_percent
+      TIERING_TARGET_SSD_RETENTION = var.tiering_obs_target_ssd_retention
+      TIERING_START_DEMOTE         = var.tiering_obs_start_demote
       FRONTEND_CONTAINER_CORES_NUM = var.set_dedicated_fe_container ? var.containers_config_map[var.instance_type].frontend : 0
       PROXY_URL                    = var.proxy_url
       CREATE_CONFIG_FS             = (var.smbw_enabled && var.smb_setup_protocol) || var.s3_setup_protocol

--- a/lambdas/go.mod
+++ b/lambdas/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.16
 	github.com/lithammer/dedent v1.1.0
 	github.com/rs/zerolog v1.31.0
-	github.com/weka/go-cloud-lib v0.0.0-20240617093233-87f685359620
+	github.com/weka/go-cloud-lib v0.0.0-20240711150309-5e177acf14bf
 	golang.org/x/sync v0.3.0
 )
 

--- a/lambdas/go.sum
+++ b/lambdas/go.sum
@@ -39,8 +39,8 @@ github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWR
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/weka/go-cloud-lib v0.0.0-20240617093233-87f685359620 h1:UIY01SYgeXPu47dKy9ULy5vSZf+mjI76wSoiKXgEzTc=
-github.com/weka/go-cloud-lib v0.0.0-20240617093233-87f685359620/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
+github.com/weka/go-cloud-lib v0.0.0-20240711150309-5e177acf14bf h1:o0s3CopCNc8D97E10n9yU0mHg0Jq+HhMNm7HWqhjUzM=
+github.com/weka/go-cloud-lib v0.0.0-20240711150309-5e177acf14bf/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/lambdas/main.go
+++ b/lambdas/main.go
@@ -3,6 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/weka/aws-tf/modules/deploy_weka/lambdas/common"
@@ -11,10 +16,6 @@ import (
 	"github.com/weka/aws-tf/modules/deploy_weka/lambdas/functions/terminate"
 	"github.com/weka/go-cloud-lib/logging"
 	"github.com/weka/go-cloud-lib/scale_down"
-	"os"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/rs/zerolog/log"
@@ -126,6 +127,8 @@ func clusterizeHandler(ctx context.Context, vm protocol.Vm) (string, error) {
 	setObs, _ := strconv.ParseBool(os.Getenv("SET_OBS"))
 	obsName := os.Getenv("OBS_NAME")
 	tieringSsdPercent := os.Getenv("OBS_TIERING_SSD_PERCENT")
+	tieringTargetSsdRetention, _ := strconv.Atoi(os.Getenv("TIERING_TARGET_SSD_RETENTION"))
+	tieringStartDemote, _ := strconv.Atoi(os.Getenv("TIERING_START_DEMOTE"))
 	addFrontendNum, _ := strconv.Atoi(os.Getenv("FRONTEND_CONTAINER_CORES_NUM"))
 	proxyUrl := os.Getenv("PROXY_URL")
 	createConfigFs, _ := strconv.ParseBool(os.Getenv("CREATE_CONFIG_FS"))
@@ -163,9 +166,11 @@ func clusterizeHandler(ctx context.Context, vm protocol.Vm) (string, error) {
 				ProtectionLevel: protectionLevel,
 				Hotspare:        hotspare,
 			},
-			AddFrontend: addFrontend,
-			ProxyUrl:    proxyUrl,
-			WekaHomeUrl: wekaHomeUrl,
+			AddFrontend:               addFrontend,
+			ProxyUrl:                  proxyUrl,
+			WekaHomeUrl:               wekaHomeUrl,
+			TieringTargetSSDRetention: tieringTargetSsdRetention,
+			TieringStartDemote:        tieringStartDemote,
 		},
 		Obs: protocol.ObsParams{
 			Name:              obsName,

--- a/variables.tf
+++ b/variables.tf
@@ -312,7 +312,7 @@ variable "dynamodb_hash_key_name" {
 variable "lambdas_version" {
   type        = string
   description = "Lambdas code version (hash)"
-  default     = "7c14f3a10c69ebb4f19e15b91d10d087"
+  default     = "375def37c0edee0a8ce87ae9b77d0430"
 }
 
 variable "lambdas_dist" {
@@ -422,6 +422,18 @@ variable "tiering_enable_ssd_percent" {
   type        = number
   default     = 20
   description = "When set_obs_integration is true, this variable sets the capacity percentage of the filesystem that resides on SSD. For example, for an SSD with a total capacity of 20GB, and the tiering_ssd_percent is set to 20, the total available capacity is 100GB."
+}
+
+variable "tiering_obs_target_ssd_retention" {
+  type        = number
+  description = "Target retention period (in seconds) before tiering to OBS (how long data will stay in SSD). Default is 86400 seconds (24 hours)."
+  default     = 86400
+}
+
+variable "tiering_obs_start_demote" {
+  type        = number
+  description = "Target tiering cue (in seconds) before starting upload data to OBS (turning it into read cache). Default is 10 seconds."
+  default     = 10
 }
 
 ################################################## clients variables ###################################################


### PR DESCRIPTION
`cat /tmp/clusterize.sh`:
```
#!/bin/bash
set -ex
VMS=(i-0935289202f383ade i-0ca5da09e3a1f6d23 i-0a555ee90fdf50d90 i-038eadcbd82de4e49 i-0ab0fb8c6bb3621bf i-09c8bab2286a2dc1c)
IPS=(10.0.1.104 10.0.1.57 10.0.1.68 10.0.1.254 10.0.1.89 10.0.1.203)
...
TARGET_SSD_RETENTION=86400
START_DEMOTE=10
```
from `/var/log/cloud-init-output.log`:
```
+++ weka fs group create default --target-ssd-retention=86400 --start-demote=10
FSGroupId: 0
```