### PR TITLE
feat: add weka status to status lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | [aws_lambda_function.deploy_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.fetch_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.join_nfs_finalization_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.report_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.scale_down_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.status_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
@@ -842,7 +843,7 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | Ssh key pair name to pass to the instances. | `string` | `null` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | IAM Role that will be used by AWS Lambdas, if not specified will be created automatically. If pre-created should match policy described in readme | `string` | `""` | no |
 | <a name="input_lambdas_dist"></a> [lambdas\_dist](#input\_lambdas\_dist) | Lambdas code dist | `string` | `"dev"` | no |
-| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"d34843366d8dbc165d68bd03ff608680"` | no |
+| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"7ad5ccddaf090b9b6552f6ab65351cc1"` | no |
 | <a name="input_metadata_http_tokens"></a> [metadata\_http\_tokens](#input\_metadata\_http\_tokens) | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2) | `string` | `"required"` | no |
 | <a name="input_nat_public_subnet_cidr"></a> [nat\_public\_subnet\_cidr](#input\_nat\_public\_subnet\_cidr) | CIDR block for public subnet | `string` | `"10.0.2.0/24"` | no |
 | <a name="input_nfs_interface_group_name"></a> [nfs\_interface\_group\_name](#input\_nfs\_interface\_group\_name) | Interface group name. | `string` | `"weka-ig"` | no |

--- a/lambdas/functions/status/status.go
+++ b/lambdas/functions/status/status.go
@@ -2,12 +2,13 @@ package status
 
 import (
 	"context"
+	"strings"
+
 	"github.com/weka/aws-tf/modules/deploy_weka/lambdas/common"
 	cloudLibCommon "github.com/weka/go-cloud-lib/common"
 	strgins2 "github.com/weka/go-cloud-lib/lib/strings"
 	"github.com/weka/go-cloud-lib/logging"
 	"github.com/weka/go-cloud-lib/protocol"
-	"strings"
 )
 
 func hostnameToIp(hostname string) string {

--- a/lambdas/management/status.go
+++ b/lambdas/management/status.go
@@ -1,0 +1,81 @@
+package management
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weka/aws-tf/modules/deploy_weka/lambdas/common"
+	"github.com/weka/go-cloud-lib/connectors"
+	"github.com/weka/go-cloud-lib/lib/jrpc"
+	"github.com/weka/go-cloud-lib/lib/weka"
+	"github.com/weka/go-cloud-lib/logging"
+	"github.com/weka/go-cloud-lib/protocol"
+)
+
+type StatusRequest struct {
+	DeploymentUsernameId string   `json:"username_id"`
+	DeploymentPasswordId string   `json:"password_id"`
+	AdminPasswordId      string   `json:"admin_password_id"`
+	BackendPrivateIps    []string `json:"backend_private_ips"`
+}
+
+// ManagementRequest is the request object for the management lambda
+// The operation to be performed is specified in the Type field.  The specific
+// operation payload is in the StatusRequest field. The convention here is that
+// each type value should have a corresponding embedded struct that contains
+// the payload for that specific operation.
+//
+// At this time, the only operation supported is "status"
+type ManagementRequest struct {
+	Type string `json:"type"`
+
+	StatusRequest
+}
+
+func GetWekaStatus(ctx context.Context, request StatusRequest) (protocol.WekaStatus, error) {
+	logger := logging.LoggerFromCtx(ctx)
+	logger.Debug().Msg("GetWekaStatus > Start")
+
+	usernameId := request.DeploymentUsernameId
+	if usernameId == "" {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - username id is empty")
+	}
+	passwordId := request.DeploymentPasswordId
+	if passwordId == "" {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - password id is empty")
+	}
+	adminPasswordId := request.AdminPasswordId
+	if adminPasswordId == "" {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - admin password id is empty")
+	}
+	credentials, err := common.GetDeploymentOrAdminUsernameAndPassword(usernameId, passwordId, adminPasswordId)
+	if err != nil {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - get username and password > %w", err)
+	}
+	username := credentials.Username
+	password := credentials.Password
+	logger.Debug().Msgf("GetWekaStatus > Username: %s", username)
+	jrpcBuilder := func(ip string) *jrpc.BaseClient {
+		return connectors.NewJrpcClient(ctx, ip, weka.ManagementJrpcPort, username, password)
+	}
+
+	ips := request.BackendPrivateIps
+	if len(ips) == 0 {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - backend private ips are empty")
+	}
+	logger.Debug().Msgf("GetWekaStatus > BackendPrivateIps: %v", ips)
+	jpool := &jrpc.Pool{
+		Ips:     ips,
+		Clients: map[string]*jrpc.BaseClient{},
+		Active:  "",
+		Builder: jrpcBuilder,
+		Ctx:     ctx,
+	}
+
+	systemStatus := protocol.WekaStatus{}
+	err = jpool.Call(weka.JrpcStatus, struct{}{}, &systemStatus)
+	if err != nil {
+		return protocol.WekaStatus{}, fmt.Errorf("management.Status - call SystemStatus > %w", err)
+	}
+	return systemStatus, nil
+}

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -36,7 +36,7 @@ resource "aws_iam_policy" "lambda_iam_policy" {
           "ec2:ModifyInstanceAttribute",
           "ec2:TerminateInstances",
           "ec2:DescribeInstances",
-          "ec2:CreateTags"
+          "ec2:CreateTags",
         ]
         Resource = ["*"]
       },
@@ -64,6 +64,11 @@ resource "aws_iam_policy" "lambda_iam_policy" {
         ],
         "Effect" : "Allow",
         "Resource" : ["*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = ["arn:aws:lambda:*:*:function:${var.prefix}-${var.cluster_name}*"]
       }
     ]
   })

--- a/modules/protocol_gateways/iam.tf
+++ b/modules/protocol_gateways/iam.tf
@@ -96,7 +96,7 @@ resource "aws_iam_policy" "invoke_lambda_function" {
           "arn:aws:lambda:*:*:function:${var.status_lambda_name}*",
           "arn:aws:lambda:*:*:function:${var.clusterize_lambda_name}*",
           "arn:aws:lambda:*:*:function:${var.clusterize_finalization_lambda_name}*",
-          "arn:aws:lambda:*:*:function:${var.join_nfs_finalization_lambda_name}*"
+          "arn:aws:lambda:*:*:function:${var.join_nfs_finalization_lambda_name}*",
         ]
       }
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -318,7 +318,7 @@ variable "dynamodb_hash_key_name" {
 variable "lambdas_version" {
   type        = string
   description = "Lambdas code version (hash)"
-  default     = "d34843366d8dbc165d68bd03ff608680"
+  default     = "7ad5ccddaf090b9b6552f6ab65351cc1"
 }
 
 variable "lambdas_dist" {


### PR DESCRIPTION
Adds Weka status information to the `status` lambda when `{"type": "status"} is provided.  This is implemented by extending `status` to invoke a `management` lambda.  

The management lambda operates within the VPC. It is intended to be a generic endpoint for management operations against the Weka cluster (ie. invoking jRPC APIs).

## Example

### Input
```json
  {
    "type": "status"
  }
```

### Call
```sh
aws lambda invoke --function-name "${prefix}-status-lambda" --payload <input> $output_file
```

### Output

```json
{
  "weka_status": {
    "io_status": "STARTED",
    ...
  }
}
```