### PR TITLE
[CLOUD-2147] Ensure that status returns ClusterStatus when the management lambda fails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | Ssh key pair name to pass to the instances. | `string` | `null` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | IAM Role that will be used by AWS Lambdas, if not specified will be created automatically. If pre-created should match policy described in readme | `string` | `""` | no |
 | <a name="input_lambdas_dist"></a> [lambdas\_dist](#input\_lambdas\_dist) | Lambdas code dist | `string` | `"dev"` | no |
-| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"7ad5ccddaf090b9b6552f6ab65351cc1"` | no |
+| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"87a1d3c485d6429bf993d74808b71a2a"` | no |
 | <a name="input_metadata_http_tokens"></a> [metadata\_http\_tokens](#input\_metadata\_http\_tokens) | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2) | `string` | `"required"` | no |
 | <a name="input_nat_public_subnet_cidr"></a> [nat\_public\_subnet\_cidr](#input\_nat\_public\_subnet\_cidr) | CIDR block for public subnet | `string` | `"10.0.2.0/24"` | no |
 | <a name="input_nfs_interface_group_name"></a> [nfs\_interface\_group\_name](#input\_nfs\_interface\_group\_name) | Interface group name. | `string` | `"weka-ig"` | no |

--- a/lambdas/main.go
+++ b/lambdas/main.go
@@ -320,9 +320,12 @@ func getClusterStatus(ctx context.Context, stateTable, stateTableHashKey, stateK
 			BackendPrivateIps: ips,
 		},
 	}
-	wekaStatus, err := common.InvokeLambdaFunction[protocol.WekaStatus](managementLambdaName, managementRequest)
+	var wekaStatus *protocol.WekaStatus
+	wekaStatus, err = common.InvokeLambdaFunction[protocol.WekaStatus](managementLambdaName, managementRequest)
 	if err != nil {
-		return protocol.ClusterStatus{}, fmt.Errorf("getClusterStatus > InvokeLambdaFunction: %w", err)
+		wrappedError := fmt.Errorf("getClusterStatus > InvokeLambdaFunction: %w", err)
+		log.Error().Err(wrappedError).Send()
+		wekaStatus = &protocol.WekaStatus{}
 	}
 	clusterStatus.WekaStatus = *wekaStatus
 

--- a/variables.tf
+++ b/variables.tf
@@ -318,7 +318,7 @@ variable "dynamodb_hash_key_name" {
 variable "lambdas_version" {
   type        = string
   description = "Lambdas code version (hash)"
-  default     = "7ad5ccddaf090b9b6552f6ab65351cc1"
+  default     = "87a1d3c485d6429bf993d74808b71a2a"
 }
 
 variable "lambdas_dist" {


### PR DESCRIPTION
Previously, if the management lambda failed during an invocation of the status lambda.  The result would've been a string-typed error message.  In order to maintain compatibility with scripts that call this lambda, this change updates status to instead return a `ClusterStatus` with the `WekaStatus` field set to a zero-value.

Example:
```json
{
  "weka_status": {
    "io_status": "",
    ...
  },
  ...
}
```
