### PR TITLE
[CLOUD-2188] Check for clusterization before invoking management lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ The `helper_commands` part in the output provides lambda call that can be used t
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | Ssh key pair name to pass to the instances. | `string` | `null` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | IAM Role that will be used by AWS Lambdas, if not specified will be created automatically. If pre-created should match policy described in readme | `string` | `""` | no |
 | <a name="input_lambdas_dist"></a> [lambdas\_dist](#input\_lambdas\_dist) | Lambdas code dist | `string` | `"dev"` | no |
-| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"87a1d3c485d6429bf993d74808b71a2a"` | no |
+| <a name="input_lambdas_version"></a> [lambdas\_version](#input\_lambdas\_version) | Lambdas code version (hash) | `string` | `"af3516613202954deb9c4c8dd85f2f3b"` | no |
 | <a name="input_metadata_http_tokens"></a> [metadata\_http\_tokens](#input\_metadata\_http\_tokens) | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2) | `string` | `"required"` | no |
 | <a name="input_nat_public_subnet_cidr"></a> [nat\_public\_subnet\_cidr](#input\_nat\_public\_subnet\_cidr) | CIDR block for public subnet | `string` | `"10.0.2.0/24"` | no |
 | <a name="input_nfs_capacity_reservation_id"></a> [nfs\_capacity\_reservation\_id](#input\_nfs\_capacity\_reservation\_id) | The ID of the capacity reservation in which to run the nfs clients | `string` | `null` | no |

--- a/lambdas.tf
+++ b/lambdas.tf
@@ -210,13 +210,14 @@ resource "aws_lambda_function" "management" {
   }
   environment {
     variables = {
-      LAMBDA                 = "management"
-      REGION                 = local.region
-      PREFIX                 = var.prefix
-      CLUSTER_NAME           = var.cluster_name
-      USERNAME_ID            = aws_secretsmanager_secret.weka_username.id
-      DEPLOYMENT_PASSWORD_ID = aws_secretsmanager_secret.weka_deployment_password.id
-      ADMIN_PASSWORD_ID      = aws_secretsmanager_secret.weka_password.id
+      LAMBDA                     = "management"
+      REGION                     = local.region
+      PREFIX                     = var.prefix
+      CLUSTER_NAME               = var.cluster_name
+      USERNAME_ID                = aws_secretsmanager_secret.weka_username.id
+      DEPLOYMENT_PASSWORD_ID     = aws_secretsmanager_secret.weka_deployment_password.id
+      ADMIN_PASSWORD_ID          = aws_secretsmanager_secret.weka_password.id
+      USE_SECRETMANAGER_ENDPOINT = var.secretmanager_use_vpc_endpoint
     }
   }
   tags       = var.tags_map
@@ -274,13 +275,17 @@ resource "aws_lambda_function" "status_lambda" {
   }
   environment {
     variables = {
-      LAMBDA               = "status"
-      STATE_TABLE          = local.dynamodb_table_name
-      STATE_TABLE_HASH_KEY = local.dynamodb_hash_key_name
-      STATE_KEY            = local.state_key
-      NFS_STATE_KEY        = local.nfs_state_key
-      CLUSTER_NAME         = var.cluster_name
-      MANAGEMENT_LAMBDA    = aws_lambda_function.management.function_name
+      LAMBDA                     = "status"
+      STATE_TABLE                = local.dynamodb_table_name
+      STATE_TABLE_HASH_KEY       = local.dynamodb_hash_key_name
+      STATE_KEY                  = local.state_key
+      NFS_STATE_KEY              = local.nfs_state_key
+      CLUSTER_NAME               = var.cluster_name
+      MANAGEMENT_LAMBDA          = aws_lambda_function.management.function_name
+      USERNAME_ID                = aws_secretsmanager_secret.weka_username.id
+      DEPLOYMENT_PASSWORD_ID     = aws_secretsmanager_secret.weka_deployment_password.id
+      ADMIN_PASSWORD_ID          = aws_secretsmanager_secret.weka_password.id
+      USE_SECRETMANAGER_ENDPOINT = var.secretmanager_use_vpc_endpoint
     }
   }
   tags       = var.tags_map

--- a/lambdas/management/status.go
+++ b/lambdas/management/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weka/aws-tf/modules/deploy_weka/lambdas/common"
 	"github.com/weka/go-cloud-lib/connectors"
 	"github.com/weka/go-cloud-lib/lib/jrpc"
 	"github.com/weka/go-cloud-lib/lib/weka"
@@ -12,16 +11,15 @@ import (
 	"github.com/weka/go-cloud-lib/protocol"
 )
 
-type StatusRequest struct {
-	DeploymentUsernameId string   `json:"username_id"`
-	DeploymentPasswordId string   `json:"password_id"`
-	AdminPasswordId      string   `json:"admin_password_id"`
-	BackendPrivateIps    []string `json:"backend_private_ips"`
+type WekaStatusRequest struct {
+	Username          string   `json:"username"`
+	Password          string   `json:"password"`
+	BackendPrivateIps []string `json:"backend_private_ips"`
 }
 
 // ManagementRequest is the request object for the management lambda
 // The operation to be performed is specified in the Type field.  The specific
-// operation payload is in the StatusRequest field. The convention here is that
+// operation payload is in the WekaStatusRequest field. The convention here is that
 // each type value should have a corresponding embedded struct that contains
 // the payload for that specific operation.
 //
@@ -29,31 +27,15 @@ type StatusRequest struct {
 type ManagementRequest struct {
 	Type string `json:"type"`
 
-	StatusRequest
+	WekaStatusRequest // type == "status"
 }
 
-func GetWekaStatus(ctx context.Context, request StatusRequest) (protocol.WekaStatus, error) {
+func GetWekaStatus(ctx context.Context, request WekaStatusRequest) (protocol.WekaStatus, error) {
 	logger := logging.LoggerFromCtx(ctx)
 	logger.Debug().Msg("GetWekaStatus > Start")
 
-	usernameId := request.DeploymentUsernameId
-	if usernameId == "" {
-		return protocol.WekaStatus{}, fmt.Errorf("management.Status - username id is empty")
-	}
-	passwordId := request.DeploymentPasswordId
-	if passwordId == "" {
-		return protocol.WekaStatus{}, fmt.Errorf("management.Status - password id is empty")
-	}
-	adminPasswordId := request.AdminPasswordId
-	if adminPasswordId == "" {
-		return protocol.WekaStatus{}, fmt.Errorf("management.Status - admin password id is empty")
-	}
-	credentials, err := common.GetDeploymentOrAdminUsernameAndPassword(usernameId, passwordId, adminPasswordId)
-	if err != nil {
-		return protocol.WekaStatus{}, fmt.Errorf("management.Status - get username and password > %w", err)
-	}
-	username := credentials.Username
-	password := credentials.Password
+	username := request.Username
+	password := request.Password
 	logger.Debug().Msgf("GetWekaStatus > Username: %s", username)
 	jrpcBuilder := func(ip string) *jrpc.BaseClient {
 		return connectors.NewJrpcClient(ctx, ip, weka.ManagementJrpcPort, username, password)
@@ -73,8 +55,7 @@ func GetWekaStatus(ctx context.Context, request StatusRequest) (protocol.WekaSta
 	}
 
 	systemStatus := protocol.WekaStatus{}
-	err = jpool.Call(weka.JrpcStatus, struct{}{}, &systemStatus)
-	if err != nil {
+	if err := jpool.Call(weka.JrpcStatus, struct{}{}, &systemStatus); err != nil {
 		return protocol.WekaStatus{}, fmt.Errorf("management.Status - call SystemStatus > %w", err)
 	}
 	return systemStatus, nil

--- a/variables.tf
+++ b/variables.tf
@@ -324,7 +324,7 @@ variable "dynamodb_hash_key_name" {
 variable "lambdas_version" {
   type        = string
   description = "Lambdas code version (hash)"
-  default     = "87a1d3c485d6429bf993d74808b71a2a"
+  default     = "af3516613202954deb9c4c8dd85f2f3b"
 }
 
 variable "lambdas_dist" {


### PR DESCRIPTION
This fix addresses a timeout that occurs when trying to get the weka cluster status when the Weka API password is not available.  This can occur when there is no secret manager endpoint provisioned in the VPC.  This can also occur when clusterization has not finished.

If an endpoint is available, and no other password is provided by the calling function, then the management lambda will attempt to lookup up credentials in secret manager.  When the endpoint is not provisioned, then callers should provide credentials in the body of requests to the management lambda.